### PR TITLE
Add compatibility with Symfony 5

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,9 +16,8 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-
-        $rootNode = $treeBuilder->root('gtm');
+        $treeBuilder = new TreeBuilder('gtm');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/EventListener/AddRouteListener.php
+++ b/src/EventListener/AddRouteListener.php
@@ -3,7 +3,7 @@
 namespace GtmPlugin\EventListener;
 
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManagerInterface;
 
 /**
@@ -34,9 +34,9 @@ final class AddRouteListener
     }
 
     /**
-     * @param GetResponseEvent $event
+     * @param RequestEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event): void
+    public function onKernelRequest(RequestEvent $event): void
     {
         $request = $this->request->getCurrentRequest();
 

--- a/src/EventListener/ContextListener.php
+++ b/src/EventListener/ContextListener.php
@@ -6,7 +6,7 @@ use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Sylius\Component\Currency\Context\CurrencyContextInterface;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManagerInterface;
 
 /**
@@ -55,9 +55,9 @@ final class ContextListener
     }
 
     /**
-     * @param GetResponseEvent $event
+     * @param RequestEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event): void
+    public function onKernelRequest(RequestEvent $event): void
     {
         try {
             $channel = $this->channelContext->getChannel();

--- a/src/EventListener/EnvironmentListener.php
+++ b/src/EventListener/EnvironmentListener.php
@@ -2,7 +2,7 @@
 
 namespace GtmPlugin\EventListener;
 
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManagerInterface;
 
 /**
@@ -33,9 +33,9 @@ final class EnvironmentListener
     }
 
     /**
-     * @param GetResponseEvent $event
+     * @param RequestEvent $event
      */
-    public function onKernelRequest(GetResponseEvent $event): void
+    public function onKernelRequest(RequestEvent $event): void
     {
         $this->googleTagManager->setData('env', $this->environment);
     }


### PR DESCRIPTION
Hi! This PR will add compatibility with Symfony 5. A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0. Replaced also deprecated class GetResponseEvent with RequestEvent.