### PR TITLE
Fix public js reference

### DIFF
--- a/src/DependencyInjection/GtmExtension.php
+++ b/src/DependencyInjection/GtmExtension.php
@@ -59,15 +59,13 @@ final class GtmExtension extends Extension implements PrependExtensionInterface
                         'priority' => 1000,
                     ],
                 ],
-                'sylius_shop.base.offcanvas' => [
-                    'gtm' => [
+                'sylius_shop.base#javascripts' => [
+                    'gtm_after_body' => [
                         'template' => '@GtmPlugin/after_body.html.twig',
                         'enabled' => '%gtm.inject%',
                         'priority' => -100,
                     ],
-                ],
-                'sylius_shop.base#javascripts' => [
-                    'gtm' => [
+                    'gtm_events' => [
                         'template' => '@GtmPlugin/events_javascript.html.twig',
                         'enabled' => '%gtm.features.events%',
                         'priority' => -100,

--- a/templates/events_javascript.html.twig
+++ b/templates/events_javascript.html.twig
@@ -1,1 +1,1 @@
-<script src="{{ asset('@GtmPlugin/prototype.events.js') }}" {{ sylius_test_html_attribute('gtm-events-javascript') }}></script>
+<script src="{{ asset('bundles/gtmplugin/prototype.events.js') }}" {{ sylius_test_html_attribute('gtm-events-javascript') }}></script>


### PR DESCRIPTION
This pull request includes changes to the `GtmExtension.php` and `events_javascript.html.twig` files to update the GTM plugin integration. The most important changes involve modifying the Twig hook definitions and updating the asset paths in the Twig template.

Updates to GTM plugin integration:

* [`src/DependencyInjection/GtmExtension.php`](diffhunk://#diff-bdfff3bc083b1498511724d28d9029767e3aa82f2e0af90d889d273b6bea5c64L62-R68): Modified the hook definitions by changing the keys from `sylius_shop.base.offcanvas` to `sylius_shop.base#javascripts` and updating the GTM template priorities and keys.
* [`templates/events_javascript.html.twig`](diffhunk://#diff-6338365eec7f614c12e773057c7ace6292ba17e1df65f98c91a7299f0edac4eaL1-R1): Updated the asset path for the GTM plugin's JavaScript file to use the correct bundle path.